### PR TITLE
Rack ETag support

### DIFF
--- a/lib/ahab_application.rb
+++ b/lib/ahab_application.rb
@@ -5,6 +5,10 @@ require 'honeybadger'
 require 'require_all'
 
 class AhabApplication < Sinatra::Base
+
+  use Rack::ConditionalGet
+  use Rack::ETag
+
   register Sinatra::ActiveRecordExtension
   require_all 'lib/models'
 


### PR DESCRIPTION
Use `Rack::ConditionalGet` and `Rack::ETag`. Together, they speed up subsequent requests by returning 304s when the content hasn't been modified.

On some versions of Webrick, they emit a warning. See https://bugs.ruby-lang.org/attachments/2300/204_304_keep_alive.patch

Tenderlove isn't worried, though: https://twitter.com/tenderlove/status/108999110136303617
