### PR TITLE
assets.ahab.io

### DIFF
--- a/lib/ahab_application.rb
+++ b/lib/ahab_application.rb
@@ -7,6 +7,7 @@ require 'require_all'
 class AhabApplication < Sinatra::Base
   register Sinatra::ActiveRecordExtension
   require_all 'lib/models'
+  require_all 'lib/helpers'
 
   set(:project_root)  { File.expand_path('../../', __FILE__) }
   set(:public_folder) { File.join(project_root, 'public') }
@@ -22,6 +23,8 @@ class AhabApplication < Sinatra::Base
   end
 
   use Honeybadger::Rack
+
+  helpers AssetHelpers
 
   get '/' do
     erb :index, layout: :desktop

--- a/lib/helpers/asset_helpers.rb
+++ b/lib/helpers/asset_helpers.rb
@@ -21,9 +21,15 @@ module AssetHelpers
   end
 
   def asset_url(name)
-    "/#{name}"
+    "#{asset_url_prefix}#{name}"
   end
 
   alias_method :image_url, :asset_url
+
+  private
+
+  def asset_url_prefix
+    @asset_url_prefix ||= ( ENV['RACK_ENV'] == 'production' ? '//assets.ahab.io/' : '/' )
+  end
 
 end

--- a/lib/helpers/asset_helpers.rb
+++ b/lib/helpers/asset_helpers.rb
@@ -1,0 +1,29 @@
+module AssetHelpers
+
+  def js(name)
+    "<script src='#{js_url(name)}' type='text/javascript'></script>"
+  end
+
+  def css(name)
+    "<link href='#{css_url(name)}' rel='stylesheet' type='text/css'>"
+  end
+
+  def img(name)
+    "<img src='#{image_url(name)}' />"
+  end
+
+  def js_url(name)
+    asset_url "#{name}.js"
+  end
+
+  def css_url(name)
+    asset_url "#{name}.css"
+  end
+
+  def asset_url(name)
+    "/#{name}"
+  end
+
+  alias_method :image_url, :asset_url
+
+end

--- a/lib/views/desktop.erb
+++ b/lib/views/desktop.erb
@@ -1,5 +1,7 @@
 <html>
   <head>
+    <meta http-equiv='x-dns-prefetch-control' content='on'>
+    <link rel='dns-prefetch' href='//assets.ahab.io'>
     <link href='/vendor.css' rel='stylesheet' type='text/css'>
     <link href='/application.css' rel='stylesheet' type='text/css'>
   </head>

--- a/lib/views/desktop.erb
+++ b/lib/views/desktop.erb
@@ -2,8 +2,8 @@
   <head>
     <meta http-equiv='x-dns-prefetch-control' content='on'>
     <link rel='dns-prefetch' href='//assets.ahab.io'>
-    <link href='/vendor.css' rel='stylesheet' type='text/css'>
-    <link href='/application.css' rel='stylesheet' type='text/css'>
+    <%= css :vendor %>
+    <%= css :application %>
   </head>
 
   <body>
@@ -23,7 +23,7 @@
     <footer id='page-footer' class="full-viewport">
       <div class="container_12">
         <div class="grid_6 push_3 suffix_3">
-          <img src="/moby2x.png">
+          <%= img 'moby2x.png' %>
         </div>
         <div class='grid_6 push_3 suffix_3'>
           RailsRumble 2013 project by

--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -18,19 +18,19 @@
     <h3 class='line-on-sides grid_12'><span>AHAB WAS DESIGNED FOR</span></h3>
 
     <div class="grid_4">
-      <img src="/helm2x.png">
+      <%= img 'helm2x.png' %>
       <h4>Library Authors</h4>
       <p>Deliver your JS, CSS, images, etc. into the hands of developers faster and more efficiently</p>
     </div>
 
     <div class="grid_4">
-      <img src="/clipper2x.png">
+      <%= img 'clipper2x.png' %>
       <h4>Website Authors</h4>
       <p>Keep your web applications up-to-date seamlessly without worrying over miniscule details</p>
     </div>
 
     <div class="grid_4">
-      <img src="/lighthouse2x.png">
+      <%= img 'lighthouse2x.png' %>
       <h4>Companies</h4>
       <p>Enhance your applications by creating better efficiency through consistent library management</p>
     </div>


### PR DESCRIPTION
Use assets.ahab.io for assets.
1. add DNS-prefetch for `assets.ahab.io`
2. add `AssetHelpers`, with `js`, `css`, `img`, `js_url`, `css_url`, `image_url`, and `asset_url` helper methods
3. `AssetHelpers` uses `assets.ahab.io` in production
