### PR TITLE
Cache static files

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -72,7 +72,7 @@ role :db,  LINODE_SERVER_HOSTNAME, :primary => true
 
 # Add Configuration Files & Compile Assets
 after 'deploy:update_code', :roles => :app do
-  run "cd #{latest_release} && bin/rake assets:compile"
+  run "cd #{latest_release} && bin/rake assets:compile assets:purge"
 end
 
 # Restart Passenger

--- a/lib/ahab_application.rb
+++ b/lib/ahab_application.rb
@@ -14,6 +14,8 @@ class AhabApplication < Sinatra::Base
   set :database_file, File.join(project_root, 'config/database.yml')
   set(:css_dir)       { public_folder }
 
+  set :static_cache_control, [ :public, :max_age => 300 ]
+
   configure :development do
     register Sinatra::Reloader
   end

--- a/lib/tasks/purge_assets.rake
+++ b/lib/tasks/purge_assets.rake
@@ -1,0 +1,36 @@
+namespace :assets do
+
+  def purge_request(asset, &on_purged)
+    url = asset.sub('public', 'http://assets.ahab.io')
+    Typhoeus::Request.new(url, :method => :purge).tap do |request|
+      request.on_complete(&on_purged)
+    end
+  end
+
+  def purge_assets(assets)
+    [].tap do |failed|
+      Typhoeus::Hydra.hydra.tap do |client|
+        assets.each do |asset|
+          request = purge_request(asset) do |response|
+            failed << asset unless response.success?
+          end
+          client.queue request
+        end
+
+        client.run
+      end
+    end
+  end
+
+  desc 'Purge assets from the CDN'
+  task :purge => :compile do
+    require 'typhoeus'
+    failed = purge_assets( Dir['public/**/*.*'] )
+    if failed.any?
+      abort "Failed to purge #{failed.join(', ')}"
+    else
+      puts "Purged assets"
+    end
+  end
+
+end


### PR DESCRIPTION
1. Set a `Cache-Control` header to cache static files for 5 minutes.
2. Add an `assets:purge` task to tell Fastly to purge the static assets
3. Purge assets on deploy
